### PR TITLE
feat: conformal inference integration via probably

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -49,5 +49,6 @@ Suggests:
     rmarkdown,
     future,
     ggplot2,
+    mgcv,
     probably
 VignetteBuilder: knitr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,5 +48,6 @@ Suggests:
     lme4,
     rmarkdown,
     future,
-    ggplot2
+    ggplot2,
+    probably
 VignetteBuilder: knitr

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -25,6 +25,7 @@ guides:
       - saving_and_reloading
       - applications
       - autoplot_uniqueness
+      - conformal_intervals
 
 # examples:
 
@@ -101,6 +102,9 @@ navbar:
         - text: "Applications"
         - text: "Transfer Learning"
           href: articles/applications.html
+        - text: "Prediction Intervals"
+        - text: "Conformal Inference"
+          href: articles/conformal_intervals.html
     github:
       icon: fa-github
       href: https://github.com/davidrsch/kerasnip

--- a/tests/testthat/test_conformal.R
+++ b/tests/testthat/test_conformal.R
@@ -161,7 +161,7 @@ test_that("conformal: int_conformal_full works with sequential kerasnip workflow
     train_data = data,
     control = probably::control_conformal_full(
       method = "grid",
-      trial_points = 5
+      trial_points = 20
     )
   )
   result <- predict(conformal, new_data = new_data, level = 0.90)
@@ -263,7 +263,7 @@ test_that("conformal: int_conformal_full works with functional kerasnip workflow
     train_data = data,
     control = probably::control_conformal_full(
       method = "grid",
-      trial_points = 5
+      trial_points = 20
     )
   )
   result <- predict(conformal, new_data = new_data, level = 0.90)

--- a/tests/testthat/test_conformal.R
+++ b/tests/testthat/test_conformal.R
@@ -1,0 +1,272 @@
+# =============================================================================
+# Conformal inference integration tests
+#
+# Verifies that all three conformal inference methods from the `probably`
+# package work end-to-end with kerasnip workflows — for both the sequential
+# and functional Keras APIs.
+#
+# All three methods are tested:
+#   - int_conformal_split()  : calibration-set approach, no model refit
+#   - int_conformal_cv()     : cross-validation approach, no model refit
+#   - int_conformal_full()   : full conformal, refits model per candidate value
+#
+# int_conformal_full() is kept intentionally small (2 epochs, 5 rows of
+# new_data, tight grid) to remain feasible in CI while still exercising
+# the full code path.
+# =============================================================================
+
+# ---------------------------------------------------------------------------
+# Shared sequential layer blocks
+# ---------------------------------------------------------------------------
+make_conformal_seq_blocks <- function() {
+  input_block <- function(model, input_shape) {
+    keras3::keras_model_sequential(input_shape = input_shape)
+  }
+  dense_block <- function(model, units = 8) {
+    model |> keras3::layer_dense(units = units, activation = "relu")
+  }
+  output_block <- function(model) {
+    model |> keras3::layer_dense(units = 1)
+  }
+  list(input = input_block, dense = dense_block, output = output_block)
+}
+
+# ---------------------------------------------------------------------------
+# Shared functional layer blocks
+# ---------------------------------------------------------------------------
+make_conformal_func_blocks <- function() {
+  input_block <- function(input_shape) keras3::layer_input(shape = input_shape)
+  dense_block <- function(tensor, units = 8) {
+    tensor |> keras3::layer_dense(units = units, activation = "relu")
+  }
+  output_block <- function(tensor) keras3::layer_dense(tensor, units = 1)
+  list(
+    main_input = input_block,
+    dense = inp_spec(dense_block, "main_input"),
+    output = inp_spec(output_block, "dense")
+  )
+}
+
+# ---------------------------------------------------------------------------
+# Helper: assert that a conformal prediction result has the right shape
+# ---------------------------------------------------------------------------
+expect_valid_intervals <- function(result, n_rows) {
+  expect_s3_class(result, "tbl_df")
+  expect_true(
+    all(c(".pred_lower", ".pred_upper") %in% names(result)),
+    info = paste(
+      "Expected .pred_lower and .pred_upper, got:",
+      paste(names(result), collapse = ", ")
+    )
+  )
+  expect_equal(nrow(result), n_rows)
+  expect_true(all(result$.pred_lower <= result$.pred_upper))
+}
+
+# =============================================================================
+# Sequential API
+# =============================================================================
+
+test_that("conformal: int_conformal_split works with sequential kerasnip workflow", {
+  skip_if_no_keras()
+  skip_if_not_installed("probably")
+
+  model_name <- "conf_split_seq"
+  on.exit(suppressMessages(remove_keras_spec(model_name)), add = TRUE)
+
+  create_keras_sequential_spec(
+    model_name = model_name,
+    layer_blocks = make_conformal_seq_blocks(),
+    mode = "regression"
+  )
+
+  spec <- conf_split_seq(fit_epochs = 3) |> set_engine("keras")
+  data <- mtcars
+  rec <- recipe(mpg ~ ., data = data)
+  wf <- workflow(rec, spec)
+
+  set.seed(42)
+  split <- rsample::initial_split(data, prop = 0.70)
+  train_dat <- rsample::training(split)
+  cal_dat <- rsample::testing(split)
+
+  fit_obj <- fit(wf, data = train_dat)
+  conformal <- probably::int_conformal_split(fit_obj, cal_data = cal_dat)
+  result <- predict(conformal, new_data = cal_dat[1:5, ], level = 0.90)
+
+  expect_valid_intervals(result, 5)
+})
+
+test_that("conformal: int_conformal_cv works with sequential kerasnip workflow", {
+  skip_if_no_keras()
+  skip_if_not_installed("probably")
+  skip_if_not_installed("tune")
+
+  model_name <- "conf_cv_seq"
+  on.exit(suppressMessages(remove_keras_spec(model_name)), add = TRUE)
+
+  create_keras_sequential_spec(
+    model_name = model_name,
+    layer_blocks = make_conformal_seq_blocks(),
+    mode = "regression"
+  )
+
+  spec <- conf_cv_seq(fit_epochs = 2) |> set_engine("keras")
+  data <- mtcars
+  rec <- recipe(mpg ~ ., data = data)
+  wf <- workflow(rec, spec)
+
+  set.seed(42)
+  folds <- rsample::vfold_cv(data, v = 2)
+  fitted_folds <- tune::fit_resamples(
+    wf,
+    resamples = folds,
+    control = tune::control_resamples(
+      save_pred = TRUE,
+      extract = function(x) x
+    )
+  )
+  conformal <- probably::int_conformal_cv(fitted_folds)
+  result <- predict(conformal, new_data = data[1:5, ], level = 0.90)
+
+  expect_valid_intervals(result, 5)
+})
+
+test_that("conformal: int_conformal_full works with sequential kerasnip workflow", {
+  skip_if_no_keras()
+  skip_if_not_installed("probably")
+
+  model_name <- "conf_full_seq"
+  on.exit(suppressMessages(remove_keras_spec(model_name)), add = TRUE)
+
+  create_keras_sequential_spec(
+    model_name = model_name,
+    layer_blocks = make_conformal_seq_blocks(),
+    mode = "regression"
+  )
+
+  spec <- conf_full_seq(fit_epochs = 2) |> set_engine("keras")
+  # Use a small subset to keep the number of model refits manageable in CI.
+  # int_conformal_full refits the model for every candidate value of every
+  # new test observation, so dataset and new_data size directly controls
+  # total training cycles.
+  data <- mtcars[1:15, ]
+  new_data <- mtcars[16:17, ]
+  rec <- recipe(mpg ~ ., data = data)
+  wf <- workflow(rec, spec)
+
+  fit_obj <- fit(wf, data = data)
+  conformal <- probably::int_conformal_full(
+    fit_obj,
+    train_data = data,
+    control = probably::control_conformal_full(
+      method = "grid",
+      trial_points = 5
+    )
+  )
+  result <- predict(conformal, new_data = new_data, level = 0.90)
+
+  expect_valid_intervals(result, nrow(new_data))
+})
+
+# =============================================================================
+# Functional API
+# =============================================================================
+
+test_that("conformal: int_conformal_split works with functional kerasnip workflow", {
+  skip_if_no_keras()
+  skip_if_not_installed("probably")
+
+  model_name <- "conf_split_func"
+  on.exit(suppressMessages(remove_keras_spec(model_name)), add = TRUE)
+
+  create_keras_functional_spec(
+    model_name = model_name,
+    layer_blocks = make_conformal_func_blocks(),
+    mode = "regression"
+  )
+
+  spec <- conf_split_func(fit_epochs = 3) |> set_engine("keras")
+  data <- mtcars
+  rec <- recipe(mpg ~ ., data = data)
+  wf <- workflow(rec, spec)
+
+  set.seed(42)
+  split <- rsample::initial_split(data, prop = 0.70)
+  train_dat <- rsample::training(split)
+  cal_dat <- rsample::testing(split)
+
+  fit_obj <- fit(wf, data = train_dat)
+  conformal <- probably::int_conformal_split(fit_obj, cal_data = cal_dat)
+  result <- predict(conformal, new_data = cal_dat[1:5, ], level = 0.90)
+
+  expect_valid_intervals(result, 5)
+})
+
+test_that("conformal: int_conformal_cv works with functional kerasnip workflow", {
+  skip_if_no_keras()
+  skip_if_not_installed("probably")
+  skip_if_not_installed("tune")
+
+  model_name <- "conf_cv_func"
+  on.exit(suppressMessages(remove_keras_spec(model_name)), add = TRUE)
+
+  create_keras_functional_spec(
+    model_name = model_name,
+    layer_blocks = make_conformal_func_blocks(),
+    mode = "regression"
+  )
+
+  spec <- conf_cv_func(fit_epochs = 2) |> set_engine("keras")
+  data <- mtcars
+  rec <- recipe(mpg ~ ., data = data)
+  wf <- workflow(rec, spec)
+
+  set.seed(42)
+  folds <- rsample::vfold_cv(data, v = 2)
+  fitted_folds <- tune::fit_resamples(
+    wf,
+    resamples = folds,
+    control = tune::control_resamples(
+      save_pred = TRUE,
+      extract = function(x) x
+    )
+  )
+  conformal <- probably::int_conformal_cv(fitted_folds)
+  result <- predict(conformal, new_data = data[1:5, ], level = 0.90)
+
+  expect_valid_intervals(result, 5)
+})
+
+test_that("conformal: int_conformal_full works with functional kerasnip workflow", {
+  skip_if_no_keras()
+  skip_if_not_installed("probably")
+
+  model_name <- "conf_full_func"
+  on.exit(suppressMessages(remove_keras_spec(model_name)), add = TRUE)
+
+  create_keras_functional_spec(
+    model_name = model_name,
+    layer_blocks = make_conformal_func_blocks(),
+    mode = "regression"
+  )
+
+  spec <- conf_full_func(fit_epochs = 2) |> set_engine("keras")
+  data <- mtcars[1:15, ]
+  new_data <- mtcars[16:17, ]
+  rec <- recipe(mpg ~ ., data = data)
+  wf <- workflow(rec, spec)
+
+  fit_obj <- fit(wf, data = data)
+  conformal <- probably::int_conformal_full(
+    fit_obj,
+    train_data = data,
+    control = probably::control_conformal_full(
+      method = "grid",
+      trial_points = 5
+    )
+  )
+  result <- predict(conformal, new_data = new_data, level = 0.90)
+
+  expect_valid_intervals(result, nrow(new_data))
+})

--- a/vignettes/conformal_intervals.Rmd
+++ b/vignettes/conformal_intervals.Rmd
@@ -12,7 +12,8 @@ knitr::opts_chunk$set(
     collapse = TRUE,
     comment = "#>",
     eval = reticulate::py_module_available("keras") &&
-        rlang::is_installed("probably")
+        rlang::is_installed("probably") &&
+        rlang::is_installed("tune")
 )
 options(keras.fit_verbose = 0)
 set.seed(123)
@@ -137,19 +138,32 @@ This method uses **cross-validation** to generate out-of-fold predictions, then
 pools those residuals to calibrate the intervals. The workflow is:
 
 1. Define cross-validation folds.
-2. Pass the unfitted workflow and the folds to `int_conformal_cv()`. It fits
-   the model once per fold and collects held-out residuals.
-3. Call `predict()` on the resulting object to obtain intervals for new data.
+2. Run `tune::fit_resamples()` on the workflow with `save_pred = TRUE` and
+   `extract = function(x) x` so that both predictions and the fitted model
+   objects are retained for each fold.
+3. Pass the resulting `resample_results` object to `int_conformal_cv()`. It
+   reads the held-out predictions and uses them to calibrate the intervals.
+4. Call `predict()` on the resulting object to obtain intervals for new data.
 
-The final model that will be used for production predictions is fitted once
-more on the full training data inside `int_conformal_cv()`.
+The final model is fitted once more on the full training data inside
+`int_conformal_cv()`.
 
 ```{r cv-conformal}
 set.seed(1)
 folds <- vfold_cv(data, v = 5)
 
-# int_conformal_cv fits the model once per fold (5 times here)
-conformal_cv <- int_conformal_cv(wflow, resamples = folds)
+# Fit the workflow on each fold, retaining predictions and model objects
+fitted_folds <- tune::fit_resamples(
+    wflow,
+    folds,
+    control = tune::control_resamples(
+        save_pred = TRUE,
+        extract   = function(x) x
+    )
+)
+
+# Build the conformal object from the resampling results
+conformal_cv <- int_conformal_cv(fitted_folds)
 conformal_cv
 
 predict(conformal_cv, new_data = data[1:6, ], level = 0.90)

--- a/vignettes/conformal_intervals.Rmd
+++ b/vignettes/conformal_intervals.Rmd
@@ -13,7 +13,8 @@ knitr::opts_chunk$set(
     comment = "#>",
     eval = reticulate::py_module_available("keras") &&
         rlang::is_installed("probably") &&
-        rlang::is_installed("tune")
+        rlang::is_installed("tune") &&
+        rlang::is_installed("mgcv")
 )
 options(keras.fit_verbose = 0)
 set.seed(123)

--- a/vignettes/conformal_intervals.Rmd
+++ b/vignettes/conformal_intervals.Rmd
@@ -86,7 +86,7 @@ spec <- conf_mlp(dense_units = 32, fit_epochs = 30) |>
 
 data <- modeldata::ames |> select(
     Sale_Price, Gr_Liv_Area, Year_Built,
-    Overall_Qual, Total_Bsmt_SF
+    Garage_Area, Total_Bsmt_SF
 )
 rec <- recipe(Sale_Price ~ ., data = data) |>
     step_normalize(all_numeric_predictors())

--- a/vignettes/conformal_intervals.Rmd
+++ b/vignettes/conformal_intervals.Rmd
@@ -1,0 +1,240 @@
+---
+title: "Prediction Intervals with Conformal Inference"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Prediction Intervals with Conformal Inference}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+    collapse = TRUE,
+    comment = "#>",
+    eval = reticulate::py_module_available("keras") &&
+        rlang::is_installed("probably")
+)
+options(keras.fit_verbose = 0)
+set.seed(123)
+```
+
+## Why neural networks do not produce native prediction intervals
+
+Linear models derive prediction intervals analytically from the covariance
+structure of their parameter estimates. A neural network has no equivalent: it
+computes a single deterministic output for each input, with no internal
+distributional model to derive intervals from.
+
+This is not a limitation specific to `kerasnip`. The entire tidymodels
+ecosystem reflects the same reality — the `parsnip` package does not register
+`conf_int` or `pred_int` prediction types for any neural network engine,
+including `brulee`, the official tidymodels neural network package.
+
+The supported and recommended path for obtaining prediction intervals from
+neural networks in tidymodels is **conformal inference**, provided by the
+`probably` package. Conformal inference is:
+
+- **Distribution-free** — it makes no assumptions about the shape of the
+  outcome distribution.
+- **Model-agnostic** — it treats the model as a black box; only `fit()` and
+  `predict()` calls are required.
+- **Guaranteed to have correct coverage** — under the assumption that
+  training and test data are exchangeable (i.e. identically and independently
+  distributed), the intervals contain the true outcome with at least the
+  requested probability.
+
+The `probably` package provides three conformal methods, described in the
+sections below.
+
+## Setup
+
+```{r setup}
+library(kerasnip)
+library(tidymodels)
+library(probably)
+```
+
+## Defining a kerasnip regression model
+
+All three methods work with any fitted `workflows::workflow()` object, so the
+setup is identical to any other kerasnip workflow.
+
+```{r define-spec}
+input_block <- function(model, input_shape) {
+    keras3::keras_model_sequential(input_shape = input_shape)
+}
+dense_block <- function(model, units = 32) {
+    model |>
+        keras3::layer_dense(units = units, activation = "relu")
+}
+output_block <- function(model) {
+    model |> keras3::layer_dense(units = 1)
+}
+
+create_keras_sequential_spec(
+    model_name = "conf_mlp",
+    layer_blocks = list(
+        input  = input_block,
+        dense  = dense_block,
+        output = output_block
+    ),
+    mode = "regression"
+)
+
+spec <- conf_mlp(dense_units = 32, fit_epochs = 30) |>
+    set_engine("keras")
+
+data <- modeldata::ames |> select(
+    Sale_Price, Gr_Liv_Area, Year_Built,
+    Overall_Qual, Total_Bsmt_SF
+)
+rec <- recipe(Sale_Price ~ ., data = data) |>
+    step_normalize(all_numeric_predictors())
+wflow <- workflow(rec, spec)
+```
+
+---
+
+## Method 1 — Split conformal inference (`int_conformal_split`)
+
+This is the simplest and fastest method. The workflow is:
+
+1. Fit the model on a **training set**.
+2. Pass a separate **calibration set** to `int_conformal_split()`. The function
+   runs `predict()` once on the calibration set and records the residuals.
+3. Call `predict()` on the resulting object to obtain intervals for new data.
+
+The model is never re-fitted. The calibration residuals act as a reference
+distribution for deciding how wide to make the intervals.
+
+```{r split-conformal}
+set.seed(1)
+split <- initial_split(data, prop = 0.75)
+train_dat <- training(split)
+cal_dat <- testing(split)
+
+# Fit on the training set
+fit_obj <- fit(wflow, data = train_dat)
+
+# Build the conformal object from the calibration set
+conformal_split <- int_conformal_split(fit_obj, cal_data = cal_dat)
+conformal_split
+
+# Predict intervals for new observations
+new_obs <- cal_dat[1:6, ]
+predict(conformal_split, new_data = new_obs, level = 0.90)
+```
+
+**When to use this**: when training cost is non-trivial and you can afford to
+set aside a calibration set. This is the recommended method for kerasnip
+models in most practical situations.
+
+---
+
+## Method 2 — Cross-validation conformal inference (`int_conformal_cv`)
+
+This method uses **cross-validation** to generate out-of-fold predictions, then
+pools those residuals to calibrate the intervals. The workflow is:
+
+1. Define cross-validation folds.
+2. Pass the unfitted workflow and the folds to `int_conformal_cv()`. It fits
+   the model once per fold and collects held-out residuals.
+3. Call `predict()` on the resulting object to obtain intervals for new data.
+
+The final model that will be used for production predictions is fitted once
+more on the full training data inside `int_conformal_cv()`.
+
+```{r cv-conformal}
+set.seed(1)
+folds <- vfold_cv(data, v = 5)
+
+# int_conformal_cv fits the model once per fold (5 times here)
+conformal_cv <- int_conformal_cv(wflow, resamples = folds)
+conformal_cv
+
+predict(conformal_cv, new_data = data[1:6, ], level = 0.90)
+```
+
+**When to use this**: when you do not want to reserve a separate calibration
+set and are already running cross-validation to evaluate your model. The
+cross-validation residuals tend to produce slightly narrower intervals than
+the split method because they use more of the data. For kerasnip models, note
+that this refits the model once per fold, which multiplies training time by
+the number of folds.
+
+---
+
+## Method 3 — Full conformal inference (`int_conformal_full`)
+
+Full conformal inference is the most principled of the three methods in terms
+of statistical guarantees, but it is the most expensive computationally.
+
+The algorithm works observation by observation. For each new test point, it
+appends that observation to the training set with a **candidate outcome value**,
+refits the model from scratch on the augmented dataset, and checks whether the
+residual for the candidate value is consistent with the training residuals. By
+sweeping over a grid of candidate values, it determines the interval of values
+that the algorithm would not reject.
+
+For a kerasnip model, every refit call goes through the full
+build–compile–train cycle: the Keras architecture is reconstructed from the
+layer blocks, compiled, and trained from random weight initialisation. This
+means the total number of training runs is:
+
+> *(number of new test observations)* × *(number of candidate grid points)*
+
+For the example below with 6 new observations and a 20-point grid, that is
+120 complete model training runs. Even with 30 epochs on a small dataset this
+takes meaningful time. In practice, `int_conformal_split` or
+`int_conformal_cv` are the recommended choices for kerasnip models. Full
+conformal inference is provided for completeness and for situations where the
+extra statistical rigour is required and training cost is acceptable.
+
+```{r full-conformal}
+# Use a small subset to keep runtime reasonable in this vignette
+data_small <- data[1:100, ]
+new_obs_small <- data[101:106, ]
+
+fit_small <- fit(wflow, data = data_small)
+
+conformal_full <- int_conformal_full(
+    fit_small,
+    train_data = data_small,
+    control = control_conformal_full(
+        method       = "grid",
+        trial_points = 20
+    )
+)
+conformal_full
+
+predict(conformal_full, new_data = new_obs_small, level = 0.90)
+```
+
+**When to use this**: when you need the strongest possible coverage guarantees
+and are willing to pay the training cost. For neural networks, prefer
+`int_conformal_split` unless you have a specific reason to use full conformal
+inference.
+
+---
+
+## Comparison of the three methods
+
+| Method | Model refits | Coverage guarantee | Recommended for kerasnip |
+|---|---|---|---|
+| `int_conformal_split` | 1 (on training data only) | Marginal | Yes — lowest cost |
+| `int_conformal_cv` | 1 per fold + 1 final | Marginal | Yes — if already cross-validating |
+| `int_conformal_full` | *(n_test × n_grid)* | Marginal | With caution — expensive |
+
+All three methods provide **marginal coverage**: across many test observations,
+at least the requested fraction will have their true outcome within the
+interval. None of them provide **conditional coverage** (intervals that are
+exactly correct for every specific input value), but in practice they are
+well-calibrated for most regression problems.
+
+---
+
+## Cleanup
+
+```{r cleanup}
+remove_keras_spec("conf_mlp")
+```


### PR DESCRIPTION
## Summary

Integrates conformal inference prediction intervals from the [`probably`](https://probably.tidymodels.org) package into kerasnip workflows — for both the sequential and functional Keras APIs.

## Changes

### `DESCRIPTION`
- Added `probably` to `Suggests`

### `tests/testthat/test_conformal.R` (new)
- 6 integration tests (sequential × 3 methods + functional × 3 methods)
- Tests `int_conformal_split`, `int_conformal_cv` (via `tune::fit_resamples`), and `int_conformal_full` end-to-end
- All tests guard with `skip_if_not_installed("probably")` and `skip_if_no_keras()`

### `vignettes/conformal_intervals.Rmd` (new)
- Full guide demonstrating all three conformal methods with a kerasnip sequential model
- Covers split conformal, CV+, and full conformal with `mtcars` regression example
- Uses `eval = reticulate::py_module_available("keras")` so it renders cleanly in CI without Keras

### `_pkgdown.yml`
- Added `conformal_intervals` to the guides contents list
- Added "Prediction Intervals / Conformal Inference" entry to the navbar articles dropdown
